### PR TITLE
Add option to switch picker to root namespace

### DIFF
--- a/dwpicker/dialog.py
+++ b/dwpicker/dialog.py
@@ -47,7 +47,8 @@ class NamespaceDialog(QtWidgets.QDialog):
         self.setWindowTitle('Select namespace ...')
         self.namespace_combo = QtWidgets.QComboBox()
         self.namespace_combo.setEditable(True)
-        namespaces = cmds.namespaceInfo(listOnlyNamespaces=True, recurse=True)
+        namespaces = [':'] + cmds.namespaceInfo(
+            listOnlyNamespaces=True, recurse=True)
         self.namespace_combo.addItems(namespaces)
 
         self.ok = QtWidgets.QPushButton('Ok')


### PR DESCRIPTION
Hi we found that there is no way to switch from non root namespace to root, we need that as we have complex workflow when producing pickers and store picker data in rigging scene. And i think it is nice to have option.