### PR TITLE
Fix toggle panel view

### DIFF
--- a/dwpicker/main.py
+++ b/dwpicker/main.py
@@ -286,10 +286,10 @@ class DwPicker(DockableBase, QtWidgets.QWidget):
         picker = self.tab.currentWidget()
         if picker is None:
             return
-
+        focused_panel = picker.reset()
         picker.as_sub_tab = state
         picker.create_pickers()
-        picker.create_panels()
+        picker.create_panels(panel=focused_panel)
         QtCore.QTimer.singleShot(10, partial(picker.reset, force_all=True))
         picker.update()
 

--- a/dwpicker/picker.py
+++ b/dwpicker/picker.py
@@ -107,6 +107,7 @@ class PickerStackedView(QtWidgets.QWidget):
         self.editable = editable
         self.pickers = []
         self.widget = None
+        self.last_selected_tab = None
 
         self.layers_menu = VisibilityLayersMenu(document)
         self.layers_menu.visibilities_changed.connect(self.update)
@@ -181,9 +182,15 @@ class PickerStackedView(QtWidgets.QWidget):
             names = data['general']['panels.names']
             for picker, name in zip(self.pickers, names):
                 self.widget.addTab(picker, name)
+            if self.last_selected_tab:
+                self.widget.setCurrentIndex(self.last_selected_tab)
+            self.widget.currentChanged.connect(self.on_tab_changed)
 
         clear_layout(self.layout)
         self.layout.addWidget(self.widget)
+
+    def on_tab_changed(self, index):
+        self.last_selected_tab = index
 
     def full_refresh(self):
         panels = self.document.data['general']['panels']

--- a/dwpicker/picker.py
+++ b/dwpicker/picker.py
@@ -132,7 +132,7 @@ class PickerStackedView(QtWidgets.QWidget):
             for picker in self.pickers:
                 if picker.rect().contains(get_cursor(picker)):
                     picker.reset()
-                    return
+                    return picker.panel
 
         elif not force_all:
             picker = self.pickers[self.widget.currentIndex()]
@@ -170,7 +170,7 @@ class PickerStackedView(QtWidgets.QWidget):
         for picker in self.pickers:
             picker.size_event_triggered.connect(self.picker_resized)
 
-    def create_panels(self):
+    def create_panels(self, panel=None):
         data = self.document.data
         if not self.as_sub_tab:
             panels = data['general']['panels']
@@ -182,7 +182,13 @@ class PickerStackedView(QtWidgets.QWidget):
             names = data['general']['panels.names']
             for picker, name in zip(self.pickers, names):
                 self.widget.addTab(picker, name)
-            if self.last_selected_tab:
+
+            # Check "if panel is not None" (0 is a valid value,
+            # so "if panel" would be incorrect)
+            if panel is not None:
+                self.widget.setCurrentIndex(panel)
+                self.last_selected_tab = panel
+            elif self.last_selected_tab:
                 self.widget.setCurrentIndex(self.last_selected_tab)
             self.widget.currentChanged.connect(self.on_tab_changed)
 


### PR DESCRIPTION
This PR fixes the toggle panel view. Previously, when switching between sub-tabs and panel view, the selected tab would always reset to the first one. This update ensures that the last selected tab is remembered for a better user experience.

https://github.com/user-attachments/assets/3f12d43d-c835-44af-b875-a3d831f932c2

