### PR TITLE
Fix excessive undo entries

### DIFF
--- a/dwpicker/selection.py
+++ b/dwpicker/selection.py
@@ -13,7 +13,7 @@ class NameclashError(BaseException):
 def select_targets(shapes, selection_mode='replace'):
     shapes = [s for s in shapes if s.targets()]
     hovered = [s for s in shapes if s.hovered]
-    targets = [t for s in hovered for t in s.targets() if cmds.objExists(t)]
+    targets = {t for s in hovered for t in s.targets() if cmds.objExists(t)}
 
     current_selection = set(cmds.ls(selection=True, long=True))
     targets_selection = set(cmds.ls(targets, long=True))


### PR DESCRIPTION
Hi! First of all, thank you for this project! It has proven to be very useful at Squeeze Studio Animation. :smile: 

This MR fixes an annoyance where dwpicker can registers excessive undos.

Steps to reproduce:
1. Open a picker file.
2. Perform an undoable operation in the scene.
3. Click multiple times in the picker (even outside of a button, e.g., on the background).
4. Try undoing the operation from step 2 — notice the extra undos.

This behavior is not specific to dwpicker. Maya adds commands to the undo queue even if they don't alter the scene state. I contacted Autodesk about this, and they suggested submitting a feature request here:
https://forums.autodesk.com/t5/maya-ideas/consolidate-undo-steps-for-selection/idi-p/13331011

Until this is addressed, it’s the responsibility of individual tools like dwpicker to ensure they don’t create excessive undos.