### PR TITLE
fix support for nested namespaces

### DIFF
--- a/dwpicker/namespace.py
+++ b/dwpicker/namespace.py
@@ -22,7 +22,7 @@ def node_namespace(node):
     basename = node.split("|")[-1]
     if ":" not in node:
         return None
-    return basename.split(":")[0]
+    return basename.rsplit(":", 1)[0]
 
 
 def node_full_namespace(node):


### PR DESCRIPTION
when calling dwpicker.current_namespace() on nested references, it would only return the first namespace. Now it returns the namespace as it is seen in the namespace combobox