### PR TITLE
Add missing parent parameter to QAction for Maya 2019

### DIFF
--- a/dwpicker/picker.py
+++ b/dwpicker/picker.py
@@ -794,7 +794,7 @@ class VisibilityLayersMenu(QtWidgets.QMenu):
     def update_actions(self):
         self.clear()
         layers = list(self.document.shapes_by_layer)
-        action = QtWidgets.QAction('Show all')
+        action = QtWidgets.QAction('Show all', self)
         for layer in layers:
             action = QtWidgets.QAction(layer, self)
             action.setCheckable(True)


### PR DESCRIPTION
## Description

Fixes a `TypeError` that occurs when opening dwpicker in Maya 2019.

## Problem

When dwpicker is loaded in Maya 2019, the following error occurs:

```python
TypeError: 'PySide2.QtWidgets.QAction' called with wrong argument types:
  PySide2.QtWidgets.QAction(str)
Supported signatures:
  PySide2.QtWidgets.QAction(PySide2.QtCore.QObject)
  PySide2.QtWidgets.QAction(unicode, PySide2.QtCore.QObject)
```

This happens in the `VisibilityLayersMenu.update_actions()` method when creating a QAction without a parent parameter.

## Root Cause

Maya 2019 uses PySide2 2.0.x, which requires the parent parameter in the QAction constructor. Newer Maya versions (2022+) use PySide2 5.12+, where the parent parameter is optional.

## Solution

Added the missing `self` (parent) parameter to the QAction constructor on line 798 of `picker.py`:

```python
# Before
action = QtWidgets.QAction('Show all')

# After
action = QtWidgets.QAction('Show all', self)
```

This ensures backward compatibility with Maya 2019 while maintaining functionality in newer versions.

## Testing

- ✅ Tested in Maya 2019 - error resolved, dwpicker opens successfully
- ✅ No regressions expected in Maya 2022+ (parent parameter still valid)