### PR TITLE
Fix workspace restore SyntaxError and close event AttributeError

### DIFF
--- a/dwpicker/__init__.py
+++ b/dwpicker/__init__.py
@@ -53,7 +53,7 @@ def show(
     global _dwpicker
     if not _dwpicker:
         warn_if_update_available()
-        _dwpicker = DwPicker(
+        DwPicker(
             replace_namespace_function=replace_namespace_function,
             list_namespaces_function=list_namespaces_function)
     try:

--- a/dwpicker/main.py
+++ b/dwpicker/main.py
@@ -84,6 +84,10 @@ class DwPicker(DockableBase, QtWidgets.QWidget):
         self.replace_namespace_custom_function = replace_namespace_function
         self.list_namespaces_function = list_namespaces_function
 
+        # Register this instance globally for callbacks
+        import dwpicker
+        dwpicker._dwpicker = self
+
         self.editable = True
         self.callbacks = []
         self.stored_focus = None

--- a/dwpicker/qtutils.py
+++ b/dwpicker/qtutils.py
@@ -22,10 +22,11 @@ HALIGNS = {
     'center': QtCore.Qt.AlignHCenter,
     'right': QtCore.Qt.AlignRight}
 HERE = os.path.dirname(__file__)
+# Escape newlines for code generation
 ERROR_IMPORT_MSG = ('''
 ERROR: Dwpicker: DwPicker is not found in Python paths.
     - Please use sys.path.append('<dwpicker forlder>') and relaunch it.
-    - Or add '<picker folder>' to environment variable PYTHONPATH''')
+    - Or add '<picker folder>' to environment variable PYTHONPATH''').replace('\n', '\\n')
 
 RESTORE_CMD = ("""
 try:


### PR DESCRIPTION
## Description

Fixes workspace restore `SyntaxError` and close event `AttributeError`.

Closes #178

## Problems

1. **Workspace restore fails**: `EOL while scanning string literal` error occurs because `ERROR_IMPORT_MSG` contains unescaped newlines in the `uiScript` command

2. **Closing restored window fails**: `AttributeError: 'NoneType' object has no attribute 'close_event'` occurs because `dwpicker._dwpicker` is not set when restored via `restore()` method

## Solution

1. Escape newlines in `ERROR_IMPORT_MSG` by adding `.replace('\n', '\\n')`
2. Move `_dwpicker` global variable registration from `show()` to `__init__()` to support both `show()` and `restore()` code paths

## Testing

- ✅ Tested in Maya 2018, 2019, 2022, 2025, 2026
- ✅ Workspace restore works without `SyntaxError`
- ✅ Closing restored window works without `AttributeError`